### PR TITLE
Automatic recycling of obsoleted or malfunctioning servers

### DIFF
--- a/config/config.defaults.php
+++ b/config/config.defaults.php
@@ -31,7 +31,10 @@ $config = [
     'recordings_path_target' => '/mnt/scalelite-recordings/var/bigbluebutton/published/presentation',
 
     'maintenance_file_suffix' => '_ServersInMaintenance',
-    'reboot_file_suffix' => '_ServersToReboot',
+
+    // Max uptime in seconds above which a server is forcibly recycled
+    // This is to prevent errors that might occur after a long uptime
+    'server_max_recycling_uptime' => 60*60*24*30,
 
     // Adaptation from schedule
     'ical_cached_file_suffix' => '_adaptationCalendar',

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1562,7 +1562,7 @@ class ServersPool
 
         // If there are still servers to replace, terminate them if at least a server is fully functional
         $current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online', 'custom_state' => null], true, false);
-        if (!empty($current_fully_functional_servers)) {
+        if (true) {
             foreach ($current_active_to_replace_servers_copy as $domain => $v) {
                 $this->logger->info("Server is due to be terminated. Add server to cordon list.", ['domain' => $domain, 'custom_state' => $v['custom_state']]);
                 $to_terminate_servers[] = $domain;

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -212,7 +212,7 @@ class ServersPool
      * @param int $sec Number of seconds to convert
      * @return string The readable duration
      */
-    private function convertSecToTime(int $sec)
+    private function convertSecToTime(int $secs)
     {
         if (!$secs = (int)$secs)
             return '0 seconds';

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1509,8 +1509,8 @@ class ServersPool
 
         // Cordon unresponsive servers: they will be terminated
         // Unless there is only one active online server, in this case we wait until a second server starts and comes online
-        $current_active_online_servers = $this->getList(['scalelite_state' => 'enabled', 'scalelite_status' => 'online', 'hoster_state' => 'running'], true, false);
-        if (count($current_active_online_servers) > 1) {
+        $current_active_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'scalelite_status' => 'online', 'bbb_status' => 'OK', 'hoster_state' => 'running'], true, false);
+        if (count($current_active_fully_functional_servers) >= 1) {
             $unresponsive_servers_to_cordon = [];
             foreach ($current_active_servers as $domain => $v) {
                 if ($v['custom_state'] == 'unresponsive') {

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1568,16 +1568,17 @@ class ServersPool
         // But keep one server alive in case the number of server to replaces matches the number of online servers
         //$current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online', 'custom_state' => null], true, false);
         if (count($current_active_to_replace_servers_copy) == $current_active_online_servers_count) {
-            $server_to_keep = [];
             if (count($current_active_to_recycle_servers) >= 1 ) {
                 // Preferably keep a server to recycle
-                $server_to_keep = array_pop($current_active_to_recycle_servers);
+                $server_data = end($current_active_to_recycle_servers);
+                $domain = key($current_active_to_recycle_servers);
             } else {
                 // Else keep a malfunctioning server
-                $server_to_keep = array_pop($current_active_malfunctioning_servers);
+                $server_data = end($current_active_malfunctioning_servers);
+                $domain = key($current_active_malfunctioning_servers);
             }
-            $domain = key($server_to_keep);
-            $this->logger->info("Server is due to be terminated but we keep it as the only active online server.", ['domain' => $domain, 'custom_state' => $server_to_keep[$domain]['custom_state']]);
+
+            $this->logger->info("Server is due to be terminated but we keep it as the only active online server.", ['domain' => $domain, 'custom_state' => $server_data['custom_state']]);
             unset($potential_active_servers[$domain]);
             unset($current_active_to_replace_servers_copy[$domain]);
         }

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1525,7 +1525,8 @@ class ServersPool
         }
 
         // If there are still servers to replace, terminate them if at least a server is fully functional
-        if ($current_active_servers_count > $current_active_to_replace_servers_count) {
+        $current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online'], true, false);
+        if ($current_active_servers_count > $current_active_to_replace_servers_count and !empty($current_fully_functional_servers)) {
             foreach ($current_active_to_replace_servers_copy as $domain => $v) {
                 $this->logger->info("Server is due to be terminated. Add server to cordon list.", ['domain' => $domain, 'custom_state' => $v['custom_state']]);
                 $to_terminate_servers[] = $domain;

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1568,6 +1568,7 @@ class ServersPool
         // But keep one server alive in case the number of server to replaces matches the number of online servers
         //$current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online', 'custom_state' => null], true, false);
         if (count($current_active_to_replace_servers_copy) == $current_active_online_servers_count) {
+            $server_to_keep = [];
             if (count($current_active_to_recycle_servers) >= 1 ) {
                 // Preferably keep a server to recycle
                 $server_to_keep = array_pop($current_active_to_recycle_servers);

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1562,7 +1562,7 @@ class ServersPool
 
         // If there are still servers to replace, terminate them if at least a server is fully functional
         $current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online', 'custom_state' => null], true, false);
-        if ($current_active_servers_count > $current_active_to_replace_servers_count and !empty($current_fully_functional_servers)) {
+        if (!empty($current_fully_functional_servers)) {
             foreach ($current_active_to_replace_servers_copy as $domain => $v) {
                 $this->logger->info("Server is due to be terminated. Add server to cordon list.", ['domain' => $domain, 'custom_state' => $v['custom_state']]);
                 $to_terminate_servers[] = $domain;

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -194,6 +194,8 @@ class ServersPool
                     $this->logger->warning("Uptime above limit for virtual machine server $domain detected. Tag server as 'to recycle'. Server will be powered off unless it is in maintenance.", ['domain' => $domain, 'bbb_status' => $bbb_status, 'divims_state' => $servers[$domain]['divims_state']]);
                     $servers[$domain]['custom_state'] = 'to recycle';
                 }
+            } else {
+                $servers[$domain]['custom_state'] = null; 
             }
 
         }
@@ -1525,7 +1527,7 @@ class ServersPool
         }
 
         // If there are still servers to replace, terminate them if at least a server is fully functional
-        $current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online'], true, false);
+        $current_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'bbb_status' => 'OK', 'scalelite_status' => 'online', 'custom_state' => null], true, false);
         if ($current_active_servers_count > $current_active_to_replace_servers_count and !empty($current_fully_functional_servers)) {
             foreach ($current_active_to_replace_servers_copy as $domain => $v) {
                 $this->logger->info("Server is due to be terminated. Add server to cordon list.", ['domain' => $domain, 'custom_state' => $v['custom_state']]);

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1505,7 +1505,7 @@ class ServersPool
         $potential_active_servers = $this->getList(['scalelite_state' => 'enabled']);
         $current_active_unresponsive_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'custom_state' => 'unresponsive']);
         $current_active_malfunctioning_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'custom_state' => 'malfunctioning']);
-        $current_active_to_recycle_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'custom_state' => 'to_recycle']);
+        $current_active_to_recycle_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'custom_state' => 'to recycle']);
         // Cordon 'to terminate' servers: they will be terminated
         // Unless there is only one active online server, in this case we wait until a second server starts and comes online
         $current_active_fully_functional_servers = $this->getList(['scalelite_state' => 'enabled', 'scalelite_status' => 'online', 'bbb_status' => 'OK', 'hoster_state' => 'running'], true, false);

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1756,8 +1756,8 @@ class ServersPool
                         if ($servers_to_enable_count == $server_difference_count) {
                             break 2;
                         }
-                        if ($v['hoster_state'] == $hoster_state and $v['custom_state'] != 'unresponsive' and $v['custom_state'] != 'malfunctioning' and $v['custom_state'] != 'to recycle') {
-                            $this->logger->info("Register $hoster_state and {$v['scalelite_state']} in Scalelite server in enable list.", ['domain' => $domain]);
+                        if ($v['hoster_state'] == $hoster_state) {
+                            $this->logger->info("Register $hoster_state server in enable list.", ['domain' => $domain]);
                             $servers_to_enable[] = $domain;
                             unset($potential_servers_to_enable[$domain]);
                             $servers_to_enable_count++;

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1550,7 +1550,6 @@ class ServersPool
         $current_active_to_recycle_servers = $this->getList(['scalelite_state' => 'enabled', 'hoster_state' => 'running', 'custom_state' => 'to recycle']);
 
         $current_active_to_replace_servers = array_merge($current_active_unresponsive_servers, $current_active_malfunctioning_servers, $current_active_to_recycle_servers);
-        $current_active_to_replace_servers_count = count($current_active_to_replace_servers);
 
         // Unconditionnaly terminate 'unresponsive' servers
         $to_terminate_servers = [];
@@ -1573,6 +1572,7 @@ class ServersPool
         if (!empty($to_terminate_servers)) {
             $this->scaleliteActOnServersList(['action' => 'cordon', 'domains' => $to_terminate_servers]);
         }
+        $current_active_to_replace_servers_count = count($current_active_to_replace_servers_copy);
 
         $this->logger->info("Current active (running and enabled in Scalelite) virtual machines servers count: " . count($current_active_servers));
         $this->logger->info("Current active (running and enabled in Scalelite) bare metal servers count: $current_active_bare_metal_servers_count");

--- a/lib/DiViMS/ServersPool.php
+++ b/lib/DiViMS/ServersPool.php
@@ -1717,8 +1717,8 @@ class ServersPool
                     }
                 }
 
-                // Then enable servers that are quickly available
-                $ordered_hoster_states = ['starting', 'stopped in place', 'stopped', 'nonexistent'];
+                // Then enable servers ordered by their starting time
+                $ordered_hoster_states = ['starting', 'stopped in place', 'stopped', 'nonexistent', 'stopping'];
                 foreach ($ordered_hoster_states as $hoster_state) {
                     foreach ($potential_servers_to_enable as $domain => $v) {
                         if ($servers_to_enable_count == $server_difference_count) {
@@ -1742,22 +1742,6 @@ class ServersPool
                         }
                         if ($v['hoster_state'] == 'running' and $v['custom_state'] == $custom_state) {
                             $this->logger->info("Register (re-enable) running and $custom_state server in enable list.", ['domain' => $domain]);
-                            $servers_to_enable[] = $domain;
-                            unset($potential_servers_to_enable[$domain]);
-                            $servers_to_enable_count++;
-                        }
-                    }
-                }
-
-                // Then enable servers with longest starting time
-                $ordered_hoster_states = ['stopping'];
-                foreach($ordered_hoster_states as $hoster_state) {
-                    foreach ($potential_servers_to_enable as $domain => $v) {
-                        if ($servers_to_enable_count == $server_difference_count) {
-                            break 2;
-                        }
-                        if ($v['hoster_state'] == $hoster_state) {
-                            $this->logger->info("Register $hoster_state server in enable list.", ['domain' => $domain]);
                             $servers_to_enable[] = $domain;
                             unset($potential_servers_to_enable[$domain]);
                             $servers_to_enable_count++;


### PR DESCRIPTION
This contribution allows obsoleted servers (servers whose uptime exceeds a defined duration) and malfunctioning servers (functional servers with one or several faulty BBB services) to be automatically replaced by new ones.

The servers tagged to be replaced are first cordoned to make sure they get drained (just as it is done when pool load goes down and the number of active servers needs to be reduced).

It is all the more important to replace obsoleted servers than errors may occur after a long uptime.